### PR TITLE
Add homepage and configuration for Engineering & AI blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,17 @@
+title: "Engineering & AI the Right Way"
+description: >-
+  Exploring thoughtful approaches to building resilient engineering systems and responsible artificial intelligence.
+baseurl: ""
+url: ""
+
+# Build settings
+markdown: kramdown
+theme: minima
+
+author:
+  name: "Engineering & AI the Right Way"
+  email: ""
+
+social_links:
+  github: hieutrtr
+  linkedin: ""

--- a/index.md
+++ b/index.md
@@ -1,0 +1,14 @@
+---
+layout: home
+title: Engineering & AI the Right Way
+---
+
+Welcome to **Engineering & AI the Right Way**, a journal exploring disciplined engineering practices and responsible artificial intelligence.
+
+Here you'll find:
+
+- Practical guides for building maintainable systems.
+- Insights on aligning AI solutions with ethical principles and real-world needs.
+- Reflections on the intersection of technology, people, and process.
+
+Stay tuned for deep dives, tutorials, and perspectives aimed at creating thoughtful, future-ready solutions.


### PR DESCRIPTION
## Summary
- add a Jekyll configuration file with site metadata for Engineering & AI the Right Way
- create a homepage introduction for the blog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de7a21bc04832d80a161bff66483b8