### PR TITLE
Refine messaging around professional AI usage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: "Engineering & AI the Right Way"
 description: >-
-  Exploring thoughtful approaches to building resilient engineering systems and responsible artificial intelligence.
+  Exploring thoughtful approaches to building resilient engineering systems and using artificial intelligence professionally.
 baseurl: ""
 url: ""
 

--- a/index.md
+++ b/index.md
@@ -2,13 +2,12 @@
 layout: home
 title: Engineering & AI the Right Way
 ---
-
-Welcome to **Engineering & AI the Right Way**, a journal exploring disciplined engineering practices and responsible artificial intelligence.
+Welcome to **Engineering & AI the Right Way**, a journal dedicated to professional, disciplined engineering practices and the
+pragmatic use of artificial intelligence.
 
 Here you'll find:
-
 - Practical guides for building maintainable systems.
-- Insights on aligning AI solutions with ethical principles and real-world needs.
+- Strategies for applying AI tools to deliver reliable, high-quality solutions.
 - Reflections on the intersection of technology, people, and process.
 
-Stay tuned for deep dives, tutorials, and perspectives aimed at creating thoughtful, future-ready solutions.
+Stay tuned for deep dives, tutorials, and perspectives aimed at helping teams put engineering and AI to work the right way.


### PR DESCRIPTION
## Summary
- refresh the homepage intro to emphasize professional, pragmatic applications of AI alongside disciplined engineering
- align the site description with the focus on using AI tools responsibly in a professional sense rather than ethics messaging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de815e1d24832dbba9f315cca1d89c