### PR TITLE
Add Vietnamese localization and language switcher

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,10 @@ description: >-
   Exploring thoughtful approaches to building resilient engineering systems and using artificial intelligence professionally.
 baseurl: ""
 url: ""
+lang: en
+languages:
+  en: English
+  vi: Tiếng Việt
 
 # Build settings
 markdown: kramdown

--- a/_includes/lang-switcher.html
+++ b/_includes/lang-switcher.html
@@ -1,0 +1,36 @@
+{% if page.ref and site.languages %}
+  {% assign post_translations = site.posts | where: "ref", page.ref | where_exp: "item", "item.lang != page.lang" %}
+  {% assign page_translations = site.pages | where: "ref", page.ref | where_exp: "item", "item.lang != page.lang" %}
+  {% assign translations = post_translations | concat: page_translations %}
+  {% assign available = '' | split: '' %}
+  {% for entry in site.languages %}
+    {% assign lang_code = entry[0] %}
+    {% if lang_code == page.lang %}
+      {% assign available = available | push: entry %}
+    {% else %}
+      {% assign translation = translations | where: "lang", lang_code | first %}
+      {% if translation %}
+        {% assign available = available | push: entry %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+  {% if available.size > 1 %}
+    <nav class="lang-switcher" aria-label="Language selector">
+      {% for entry in available %}
+        {% assign lang_code = entry[0] %}
+        {% assign lang_label = entry[1] %}
+        {% if lang_code == page.lang %}
+          <span class="lang-switcher__current">{{ lang_label }}</span>
+        {% else %}
+          {% assign translation = translations | where: "lang", lang_code | first %}
+          {% if translation %}
+            <a class="lang-switcher__link" href="{{ translation.url | relative_url }}">{{ lang_label }}</a>
+          {% endif %}
+        {% endif %}
+        {% unless forloop.last %}
+          <span class="lang-switcher__separator">|</span>
+        {% endunless %}
+      {% endfor %}
+    </nav>
+  {% endif %}
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,26 @@
+---
+layout: default
+---
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    {% if page.description %}
+      <p class="post-description">{{ page.description }}</p>
+    {% endif %}
+    <p class="post-meta">
+      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
+        {{ page.date | date: "%b %-d, %Y" }}
+      </time>
+      {% if page.author %}
+        • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
+      {% endif %}
+    </p>
+    {% include lang-switcher.html %}
+  </header>
+
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/_posts/2024-08-16-ready-for-autonomy-checkpoints-vi.md
+++ b/_posts/2024-08-16-ready-for-autonomy-checkpoints-vi.md
@@ -1,0 +1,174 @@
+---
+layout: post
+title: "Sẵn sàng cho tự động hóa: Điểm kiểm soát định hình Claude Code 2.0"
+description: "Vì sao khả năng tua ngược là cơ chế xây dựng niềm tin cho các tác nhân lập trình tự động như Claude Code 2.0."
+featured: false
+lang: vi
+ref: ready-for-autonomy-checkpoints
+permalink: /vi/ready-for-autonomy-checkpoints/
+---
+
+# 📰 Sẵn sàng cho tự động hóa: Điểm kiểm soát định hình Claude Code 2.0
+
+---
+
+## 🚀 Từ tự động hoàn thành sang tự chủ
+Trong vài năm qua, AI trong phát triển phần mềm chủ yếu xoay quanh tốc độ và sự tiện lợi. GitHub Copilot, ChatGPT, Claude —
+chúng gợi ý mã, giải thích lỗi, dựng khung hàm. Hữu ích, nhưng vẫn luôn bị ràng buộc vào lập trình viên.
+
+Giờ đây, chúng ta đang chứng kiến sự dịch chuyển: các tác nhân lập trình không chỉ gợi ý mà còn **hành động**. Chúng di
+chuyển giữa các tệp, tái cấu trúc mô-đun, chạy kiểm thử và commit. Chúng không còn là tính năng tự động hoàn thành —
+chúng trở thành cộng tác viên.
+
+Nhưng tự chủ mà không kiểm soát thì liều lĩnh. Trước khi để AI tự do trong codebase, chúng ta cần một thứ trên hết: **một
+cách tin cậy để quay ngược.**
+
+**Ví dụ:**
+Hãy tưởng tượng bạn nói với một trợ lý AI:
+> "Cập nhật dịch vụ thanh toán để xử lý huỷ gói đăng ký."
+Thay vì chỉ gợi ý đoạn mã, nó chỉnh sửa nhiều tệp, cập nhật tuyến API và viết kiểm thử — tất cả đều tự động.
+Không có kiểm soát, bạn sẽ lo lắng: *nếu nó làm hỏng phần lập hóa đơn thì sao?*
+
+Điểm kiểm soát xuất hiện như "nút hoàn tác cho tự chủ".
+
+---
+
+## 🛑 Vì sao tự chủ cần bàn đạp phanh
+Các tác nhân AI giống như những thực tập sinh háo hức — nhanh, liều và đôi lúc bất cẩn.
+
+**Ví dụ:**
+Bạn yêu cầu tác nhân dọn dẹp tiện ích cơ sở dữ liệu. Nó quyết định xoá các script migration SQL "không dùng". Hoá ra một script vẫn được dùng ở staging. Pipeline thất bại.
+
+Với điểm kiểm soát, bạn quay lại ngay lập tức. Không có chúng, bạn sẽ phải gỡ lỗi hậu quả trên production.
+
+---
+
+## 🔍 Điểm kiểm soát thực chất là gì
+Một điểm kiểm soát đơn giản về khái niệm nhưng có tác động sâu rộng:
+
+- **Chụp nhanh trước khi thay đổi** → Môi trường được lưu trước mỗi hành động của AI.
+- **Tua ngược một bước** → Bạn quay lại trạng thái an toàn ngay lập tức.
+- **Dòng thời gian chỉnh sửa** → Mọi nỗ lực, thành công hay thất bại, đều trở thành lịch sử có thể khôi phục.
+
+Nó giống như trao cho tác nhân AI mạng lưới an toàn mà lập trình viên con người vẫn dựa vào: quản lý phiên bản, nút hoàn tác và nhánh độc lập — nhưng ở **cấp độ thực thi của tác nhân**.
+
+**Ví dụ:**
+- Điểm kiểm soát 1: Repo ổn định.
+- Điểm kiểm soát 2: Sau khi tác nhân đổi tên các lớp.
+- Điểm kiểm soát 3: Sau khi tác nhân cập nhật phụ thuộc.
+
+Nếu điểm kiểm soát 3 gây lỗi runtime, bạn quay lại điểm 2 — thay vì phải clone lại repo.
+
+---
+
+## 👥 Điểm kiểm soát + tác nhân phụ = Giao việc an toàn
+Tác nhân phụ giúp AI chia nhỏ nhiệm vụ: một tác nhân lo tái cấu trúc, một tác nhân viết kiểm thử, một tác nhân viết tài liệu.
+
+**Ví dụ:**
+- Tác nhân A: Tái cấu trúc `AuthService`.
+- Tác nhân B: Viết unit test.
+- Tác nhân C: Cập nhật tài liệu API.
+
+Tác nhân kiểm thử thất bại — nhưng bạn chỉ tua lại những thay đổi của nó. Việc tái cấu trúc và tài liệu vẫn được giữ nguyên.
+👉 Song song mà không hỗn loạn.
+
+---
+
+## ⚓ Điểm kiểm soát + hooks = Lan can đang hoạt động
+Hooks định nghĩa chính sách. Điểm kiểm soát giúp chúng được thực thi.
+
+**Ví dụ:**
+Hook: *"Chạy linter sau mỗi commit."*
+- Nếu tác nhân tạo ra lỗi style → Hook thất bại → Repo quay lại điểm kiểm soát trước đó.
+- Lỗi không bao giờ chạm tới `main`.
+
+Nó giống như CI/CD — nhưng tức thời, bên trong phiên làm việc của tác nhân.
+
+---
+
+## ⏳ Điểm kiểm soát + tác vụ nền = Bền bỉ lâu dài
+Các bài kiểm thử và build dài hơi không kìm hãm tự chủ. Điểm kiểm soát bảo vệ bạn khỏi lãng phí thời gian.
+
+**Ví dụ:**
+Tác nhân chạy bộ kiểm thử Selenium 90 phút sau khi thay đổi UI.
+- Phút thứ 80 → 10% kiểm thử thất bại.
+- Hook kích hoạt quay lại điểm kiểm soát trước khi đổi UI.
+- Tác nhân thử lại với bản sửa.
+
+Thay vì bạn phát hiện lỗi vào sáng hôm sau, AI bắt và sửa ngay trong lúc chạy.
+
+---
+
+## 🧑‍💻 Ý nghĩa với lập trình viên
+Đối với từng lập trình viên, điểm kiểm soát mang lại ba chuyển dịch lớn:
+
+1. **Tự do khám phá** — Bạn có thể để tác nhân thử những lần tái cấu trúc táo bạo mà không sợ hỏng hốc vĩnh viễn.
+2. **Tập trung vào kết quả** — Thay vì kiểm soát từng dòng, bạn rà soát các điểm kiểm soát như các commit.
+3. **Tự tin vào khả năng hoàn tác** — Sai lầm không còn đắt giá; chúng chỉ là một trạng thái mà bạn có thể quay lại.
+
+**Ví dụ:**
+Bình thường bạn sẽ không bao giờ để AI chỉnh sửa 20 tệp cùng lúc. Quá rủi ro.
+Với điểm kiểm soát, bạn có thể nói:
+> "Tái cấu trúc toàn bộ controller sang async/await."
+Nếu có gì hỏng, bạn chỉ việc tua lại.
+Rủi ro trở nên có thể đảo ngược.
+
+---
+
+## 🏢 Ý nghĩa với đội ngũ
+Điểm kiểm soát không thay thế Git. Chúng tồn tại trong phiên làm việc cục bộ của tác nhân. Nhưng chúng tạo ra niềm tin.
+
+**Ví dụ:**
+Quy trình đội ngũ:
+1. Dev chạy Claude tại máy → nhiều điểm kiểm soát khi AI thử nghiệm.
+2. Khi ổn định, commit thay đổi → mở PR.
+3. Team review → merge.
+
+Nếu có gì hỏng sau khi merge, bạn vẫn dựa vào lịch sử Git. Nhưng trước khi review, điểm kiểm soát giúp dev tự tin để AI thử nghiệm.
+
+---
+
+## 🌍 Góc nhìn chiến lược: Khả năng tua ngược trước tự động hóa
+Khi nói về tự động hóa của AI, cuộc trò chuyện thường lệch sang năng lực: mô hình lớn hơn, tác nhân thông minh hơn, nhiều công cụ hơn. Nhưng tự chủ không chỉ là AI *có thể* làm gì — mà là chúng ta có thể *tin* nó tới mức nào.
+
+Và niềm tin đến từ kiểm soát.
+
+Trong lịch sử công nghệ, những bước nhảy vọt chỉ xảy ra sau khi chúng ta bổ sung lớp an toàn:
+- Cơ sở dữ liệu chỉ mở rộng khi có **giao dịch và rollback**.
+- Hệ điều hành chỉ ổn định khi có **cơ chế cô lập bộ nhớ**.
+- Ô tô chỉ phổ cập khi có **dây an toàn và phanh**.
+
+Với lập trình tự động, tôi tin **điểm kiểm soát là lớp còn thiếu đó**. Chúng không khiến AI "viết code giỏi hơn", nhưng khiến con người dám để AI hành động mà không sợ hãi.
+
+**Ví dụ:**
+Cơ sở dữ liệu không được tin dùng cho đến khi bạn có thể `ROLLBACK`.
+Nếu một tác nhân AI đổi tên 500 hàm, bạn cần cùng một đảm bảo: một lệnh để hoàn tác.
+
+Tự chủ mà không thể đảo ngược không phải là kỹ nghệ. Đó là đánh bạc.
+
+---
+
+## ✨ Lời kết
+Chúng ta đang ở ngưỡng chuyển mình. Hệ thống AI sẽ viết, tái cấu trúc và kiểm thử code độc lập hơn. Nhưng câu hỏi không phải
+là *liệu chúng có làm được hay không*. Đó là *liệu chúng ta có thể tin chúng khi chúng làm hay không.*
+
+Điểm kiểm soát là cơ chế xây dựng niềm tin đó.
+Bởi vì nếu AI sẽ lái repo của bạn, hãy đảm bảo nó biết cách đạp phanh.
+
+---
+
+### Công cụ lập trình AI — So sánh điểm kiểm soát & hoàn tác
+
+| Công cụ | Điểm kiểm soát / Hoàn tác | Phạm vi được chụp nhanh | Cách khôi phục & mức chi tiết | Tác nhân phụ / Điều phối | Tác vụ nền / Chạy dài hạn | Ghi chú cho độc giả |
+|---|---|---|---|---|---|---|
+| **Claude Code 2.0** | Có — tự động "checkpoint" trước khi AI chỉnh sửa | Các thay đổi do AI khởi xướng (có thể bao gồm trạng thái hội thoại khi tua) | Tua bằng lệnh/phím tắt; chi tiết cao (theo thay đổi/lệnh) | Tích hợp: hỗ trợ tác nhân phụ, hook và điều phối | Hỗ trợ tác vụ nền; hook có thể kích hoạt kiểm thử/tua lại | Cặp đôi "tác nhân" mạnh nhất: checkpoint + tác nhân phụ + hook giúp tự chủ an toàn | 
+| **VS Code Copilot Chat (Agent Mode)** | Có — "Chat Checkpoints" trong VS Code | Tệp làm việc bị AI chỉnh sửa + ngữ cảnh chat | Khôi phục từ cửa sổ chat; theo từng tương tác ("key points") | Một tác nhân điều phối công cụ (terminal, thao tác tệp); có danh sách nhiệm vụ | Có thể chạy build/kiểm thử trong một yêu cầu; chủ yếu tuần tự | Trải nghiệm trong IDE; checkpoint phục hồi cả code *và* chat để giữ phiên nhất quán | 
+| **GitHub Copilot Coding Agent (PR)** | Ngầm định thông qua PR/nhánh (không có UI checkpoint trong IDE) | Thay đổi chỉ tồn tại trong nhánh PR | Loại bỏ PR hoặc revert commit; mức độ thô (theo PR) | "Tác nhân" nền tạo PR; không lộ tác nhân phụ | Chạy tự động ngoài máy bạn; bạn review/merge | An toàn nhờ cách ly (PR). Ít tương tác, nhưng rất an toàn cho đội ngũ | 
+| **Replit AI (Agent & Assistant)** | Có — checkpoint đầy đủ & hoàn tác một cú nhấp | Toàn bộ trạng thái dự án (tệp, phụ thuộc, cấu hình môi trường, chat; tùy chọn DB) | Khôi phục từ lịch sử checkpoint; snapshot theo mốc | Một tác nhân; lập kế hoạch và thực thi tuần tự | Chạy, preview, kiểm thử trong sandbox; rollback có thể khôi phục cả môi trường/DB | Mô hình snapshot đầy đủ nhất (môi trường + code). Tuyệt vời cho quy trình web/app | 
+| **Cursor (AI Editor)** | Có — checkpoint tự động cho thay đổi của AI | Tệp dự án trước mỗi chỉnh sửa của AI (không áp dụng cho chỉnh sửa thủ công) | "Restore checkpoint" theo từng thông điệp; theo hành động AI | Một tác nhân; không có tác nhân phụ song song | Dev tự chạy kiểm thử/server; không có tác nhân nền riêng | Mạng lưới an toàn nhẹ nhàng, cục bộ; kết hợp với Git để có lịch sử bền vững | 
+| **Windsurf (AI Editor)** | Có — "Revert" về bước chat trước | Code và ngữ cảnh chat do AI tạo | Di chuột → Revert; theo từng tương tác | Một tác nhân; tích hợp auto-lint/fix | Có thể chạy/preview trong IDE; tuần tự | Giống Cursor; lặp nhanh + hoàn tác tức thì trong IDE ưu tiên AI | 
+| **Aider (CLI)** | Có — thông qua commit Git; `/undo` | Diff code (mỗi thay đổi do AI thực hiện là một commit) | `/undo` (reset commit cuối) hoặc Git bình thường; theo commit | Một tác nhân; người dùng điều phối bước | Người dùng chạy kiểm thử/server; không có tác nhân nền | Đơn giản, bền bỉ, có thể kiểm toán. Git chính là hệ thống checkpoint của bạn |
+| **Continue (VS Code/CLI)** | Một phần — dựa vào Git + "Plan Mode" | Tệp code (khuyến nghị commit nhỏ cho mỗi nhiệm vụ) | Commit/nhánh cho mỗi nhiệm vụ; không có UI checkpoint riêng | Tác nhân tuỳ chỉnh; "workflow" trên cloud mở PR | Workflow nền tạo PR; chế độ tương tác là tuần tự | An toàn nhờ quy trình: Plan Mode (chỉ đọc) → Agent Mode (thực thi) → commit/PR | 
+| **Lovable (App Builder)** | Có — Hoàn tác & lịch sử phiên bản | Phiên bản ứng dụng (code + trạng thái UI trong nền tảng) | Dòng thời gian phiên bản; tua về phiên bản trước | Một tác nhân xây dựng và tinh chỉnh ứng dụng | Triển khai một cú nhấp; không có tác nhân phụ riêng | Thân thiện với người không lập trình; lịch sử phiên bản giống checkpoint cho toàn bộ ứng dụng | 
+
+> Tóm tắt nhanh: **Claude Code 2.0, VS Code, Replit, Cursor và Windsurf** mang lại **khả năng tua ngược một chạm (hoặc một lệnh)**. **Aider và Continue** dựa vào **Git** và quy trình kỷ luật. **Claude Code 2.0** hiện là công cụ phổ biến duy nhất kết hợp **checkpoint tự động cùng tác nhân phụ, hook và tác vụ nền** để hiện thực hoá quy trình tự chủ an toàn.

--- a/_posts/2024-08-16-ready-for-autonomy-checkpoints.md
+++ b/_posts/2024-08-16-ready-for-autonomy-checkpoints.md
@@ -3,6 +3,9 @@ layout: post
 title: "Ready for Autonomy: How Checkpoints Shape Claude Code 2.0"
 description: "Why reversible checkpoints are the trust mechanism for autonomous coding agents like Claude Code 2.0."
 featured: false
+lang: en
+ref: ready-for-autonomy-checkpoints
+permalink: /ready-for-autonomy-checkpoints/
 ---
 
 # 📰 Ready for Autonomy: How Checkpoints Shape Claude Code 2.0  

--- a/index.md
+++ b/index.md
@@ -1,9 +1,13 @@
 ---
-layout: home
+layout: default
 title: Engineering & AI the Right Way
+lang: en
+ref: home
 ---
-Welcome to **Engineering & AI the Right Way**, a journal dedicated to professional, disciplined engineering practices and the
-pragmatic use of artificial intelligence.
+
+{% include lang-switcher.html %}
+
+Welcome to **Engineering & AI the Right Way**, a journal dedicated to professional, disciplined engineering practices and the pragmatic use of artificial intelligence.
 
 Here you'll find:
 - Practical guides for building maintainable systems.
@@ -11,3 +15,24 @@ Here you'll find:
 - Reflections on the intersection of technology, people, and process.
 
 Stay tuned for deep dives, tutorials, and perspectives aimed at helping teams put engineering and AI to work the right way.
+
+## Latest posts
+
+{% assign localized_posts = site.posts | where: "lang", page.lang %}
+{% if localized_posts.size > 0 %}
+<ul class="post-list">
+  {% for post in localized_posts %}
+    <li>
+      <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+      <h2>
+        <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+      </h2>
+      {% if post.description %}
+        <p>{{ post.description }}</p>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>No posts published yet.</p>
+{% endif %}

--- a/vi/index.md
+++ b/vi/index.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: Kỹ thuật & AI đúng cách
+lang: vi
+ref: home
+permalink: /vi/
+---
+
+{% include lang-switcher.html %}
+
+Chào mừng bạn đến với **Kỹ thuật & AI đúng cách** — nhật ký tập trung vào phương pháp kỹ thuật chuyên nghiệp, kỷ luật và cách vận dụng AI một cách thực dụng.
+
+Tại đây bạn sẽ tìm thấy:
+- Hướng dẫn thực tế để xây dựng hệ thống dễ bảo trì.
+- Chiến lược áp dụng công cụ AI nhằm mang lại giải pháp tin cậy, chất lượng cao.
+- Góc nhìn về giao điểm giữa công nghệ, con người và quy trình.
+
+Đón xem các bài phân tích chuyên sâu, hướng dẫn và quan điểm giúp đội ngũ đưa kỹ thuật và AI vào công việc một cách chuẩn mực.
+
+## Bài viết mới nhất
+
+{% assign localized_posts = site.posts | where: "lang", page.lang %}
+{% if localized_posts.size > 0 %}
+<ul class="post-list">
+  {% for post in localized_posts %}
+    <li>
+      <span class="post-meta">{{ post.date | date: "%d/%m/%Y" }}</span>
+      <h2>
+        <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+      </h2>
+      {% if post.description %}
+        <p>{{ post.description }}</p>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>Chưa có bài viết nào.</p>
+{% endif %}


### PR DESCRIPTION
## Summary
- configure the site for English and Vietnamese content and add a language switcher include used by localized layouts
- translate the home page and the "Ready for Autonomy" article into Vietnamese with localized permalinks

## Testing
- not run (Jekyll tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1db0033c0832d923352f913273a3f