### PR TITLE
Improve language switcher and terminology

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,48 @@
+<header class="site-header" role="banner">
+  <div class="wrapper site-header__inner">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    <div class="site-header__controls">
+      {%- assign current_lang_code = page.lang | default: site.lang | default: "en" -%}
+      {%- assign current_lang_label = site.languages[current_lang_code] | default: current_lang_code -%}
+      {%- assign language_label_text = "Language" -%}
+      {%- if current_lang_code == "vi" -%}
+        {%- assign language_label_text = "Ngôn ngữ" -%}
+      {%- endif -%}
+      {%- if site.languages and site.languages.size > 0 -%}
+        <div class="site-language" role="group" aria-label="{{ language_label_text }}">
+          <span class="site-language__current">{{ language_label_text }}: {{ current_lang_label }}</span>
+          {% include lang-switcher.html %}
+        </div>
+      {%- endif -%}
+
+      {%- if page_paths and page_paths != empty -%}
+        <nav class="site-nav">
+          <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+          <label for="nav-trigger">
+            <span class="menu-icon">
+              <svg viewBox="0 0 18 15" width="18px" height="15px" aria-hidden="true">
+                <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0h15.032
+                C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0
+                c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15
+                H1.484C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,12.031,18,12.696,18,13.516L18,13.516z" />
+              </svg>
+            </span>
+          </label>
+
+          <div class="trigger">
+            {%- for path in page_paths -%}
+              {%- assign my_page = site.pages | where: "path", path | first -%}
+              {%- if my_page.title -%}
+                <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+              {%- endif -%}
+            {%- endfor -%}
+          </div>
+        </nav>
+      {%- endif -%}
+    </div>
+  </div>
+</header>

--- a/_includes/lang-switcher.html
+++ b/_includes/lang-switcher.html
@@ -28,7 +28,7 @@
           {% endif %}
         {% endif %}
         {% unless forloop.last %}
-          <span class="lang-switcher__separator">|</span>
+          <span class="lang-switcher__separator" aria-hidden="true">|</span>
         {% endunless %}
       {% endfor %}
     </nav>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,7 +15,6 @@ layout: default
         • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author }}</span></span>
       {% endif %}
     </p>
-    {% include lang-switcher.html %}
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">

--- a/_posts/2024-08-16-ready-for-autonomy-checkpoints-vi.md
+++ b/_posts/2024-08-16-ready-for-autonomy-checkpoints-vi.md
@@ -1,18 +1,18 @@
 ---
 layout: post
-title: "Sẵn sàng cho tự động hóa: Điểm kiểm soát định hình Claude Code 2.0"
-description: "Vì sao khả năng tua ngược là cơ chế xây dựng niềm tin cho các tác nhân lập trình tự động như Claude Code 2.0."
+title: "Sẵn sàng cho Autonomy: Checkpoints định hình Claude Code 2.0"
+description: "Vì sao khả năng tua ngược là cơ chế xây dựng niềm tin cho các tác nhân lập trình Autonomous như Claude Code 2.0."
 featured: false
 lang: vi
 ref: ready-for-autonomy-checkpoints
 permalink: /vi/ready-for-autonomy-checkpoints/
 ---
 
-# 📰 Sẵn sàng cho tự động hóa: Điểm kiểm soát định hình Claude Code 2.0
+# 📰 Sẵn sàng cho Autonomy: Checkpoints định hình Claude Code 2.0
 
 ---
 
-## 🚀 Từ tự động hoàn thành sang tự chủ
+## 🚀 Từ tự động hoàn thành sang Autonomy
 Trong vài năm qua, AI trong phát triển phần mềm chủ yếu xoay quanh tốc độ và sự tiện lợi. GitHub Copilot, ChatGPT, Claude —
 chúng gợi ý mã, giải thích lỗi, dựng khung hàm. Hữu ích, nhưng vẫn luôn bị ràng buộc vào lập trình viên.
 
@@ -20,7 +20,7 @@ Giờ đây, chúng ta đang chứng kiến sự dịch chuyển: các tác nhâ
 chuyển giữa các tệp, tái cấu trúc mô-đun, chạy kiểm thử và commit. Chúng không còn là tính năng tự động hoàn thành —
 chúng trở thành cộng tác viên.
 
-Nhưng tự chủ mà không kiểm soát thì liều lĩnh. Trước khi để AI tự do trong codebase, chúng ta cần một thứ trên hết: **một
+Nhưng Autonomy mà không kiểm soát thì liều lĩnh. Trước khi để AI tự do trong codebase, chúng ta cần một thứ trên hết: **một
 cách tin cậy để quay ngược.**
 
 **Ví dụ:**
@@ -29,22 +29,22 @@ Hãy tưởng tượng bạn nói với một trợ lý AI:
 Thay vì chỉ gợi ý đoạn mã, nó chỉnh sửa nhiều tệp, cập nhật tuyến API và viết kiểm thử — tất cả đều tự động.
 Không có kiểm soát, bạn sẽ lo lắng: *nếu nó làm hỏng phần lập hóa đơn thì sao?*
 
-Điểm kiểm soát xuất hiện như "nút hoàn tác cho tự chủ".
+Checkpoints xuất hiện như "nút hoàn tác cho Autonomy".
 
 ---
 
-## 🛑 Vì sao tự chủ cần bàn đạp phanh
+## 🛑 Vì sao Autonomy cần bàn đạp phanh
 Các tác nhân AI giống như những thực tập sinh háo hức — nhanh, liều và đôi lúc bất cẩn.
 
 **Ví dụ:**
 Bạn yêu cầu tác nhân dọn dẹp tiện ích cơ sở dữ liệu. Nó quyết định xoá các script migration SQL "không dùng". Hoá ra một script vẫn được dùng ở staging. Pipeline thất bại.
 
-Với điểm kiểm soát, bạn quay lại ngay lập tức. Không có chúng, bạn sẽ phải gỡ lỗi hậu quả trên production.
+Với Checkpoints, bạn quay lại ngay lập tức. Không có chúng, bạn sẽ phải gỡ lỗi hậu quả trên production.
 
 ---
 
-## 🔍 Điểm kiểm soát thực chất là gì
-Một điểm kiểm soát đơn giản về khái niệm nhưng có tác động sâu rộng:
+## 🔍 Checkpoints thực chất là gì
+Một Checkpoint đơn giản về khái niệm nhưng có tác động sâu rộng:
 
 - **Chụp nhanh trước khi thay đổi** → Môi trường được lưu trước mỗi hành động của AI.
 - **Tua ngược một bước** → Bạn quay lại trạng thái an toàn ngay lập tức.
@@ -53,15 +53,15 @@ Một điểm kiểm soát đơn giản về khái niệm nhưng có tác độn
 Nó giống như trao cho tác nhân AI mạng lưới an toàn mà lập trình viên con người vẫn dựa vào: quản lý phiên bản, nút hoàn tác và nhánh độc lập — nhưng ở **cấp độ thực thi của tác nhân**.
 
 **Ví dụ:**
-- Điểm kiểm soát 1: Repo ổn định.
-- Điểm kiểm soát 2: Sau khi tác nhân đổi tên các lớp.
-- Điểm kiểm soát 3: Sau khi tác nhân cập nhật phụ thuộc.
+- Checkpoint 1: Repo ổn định.
+- Checkpoint 2: Sau khi tác nhân đổi tên các lớp.
+- Checkpoint 3: Sau khi tác nhân cập nhật phụ thuộc.
 
-Nếu điểm kiểm soát 3 gây lỗi runtime, bạn quay lại điểm 2 — thay vì phải clone lại repo.
+Nếu Checkpoint 3 gây lỗi runtime, bạn quay lại điểm 2 — thay vì phải clone lại repo.
 
 ---
 
-## 👥 Điểm kiểm soát + tác nhân phụ = Giao việc an toàn
+## 👥 Checkpoints + tác nhân phụ = Giao việc an toàn
 Tác nhân phụ giúp AI chia nhỏ nhiệm vụ: một tác nhân lo tái cấu trúc, một tác nhân viết kiểm thử, một tác nhân viết tài liệu.
 
 **Ví dụ:**
@@ -74,25 +74,25 @@ Tác nhân kiểm thử thất bại — nhưng bạn chỉ tua lại những th
 
 ---
 
-## ⚓ Điểm kiểm soát + hooks = Lan can đang hoạt động
-Hooks định nghĩa chính sách. Điểm kiểm soát giúp chúng được thực thi.
+## ⚓ Checkpoints + hooks = Lan can đang hoạt động
+Hooks định nghĩa chính sách. Checkpoints giúp chúng được thực thi.
 
 **Ví dụ:**
 Hook: *"Chạy linter sau mỗi commit."*
-- Nếu tác nhân tạo ra lỗi style → Hook thất bại → Repo quay lại điểm kiểm soát trước đó.
+- Nếu tác nhân tạo ra lỗi style → Hook thất bại → Repo quay lại Checkpoints trước đó.
 - Lỗi không bao giờ chạm tới `main`.
 
 Nó giống như CI/CD — nhưng tức thời, bên trong phiên làm việc của tác nhân.
 
 ---
 
-## ⏳ Điểm kiểm soát + tác vụ nền = Bền bỉ lâu dài
-Các bài kiểm thử và build dài hơi không kìm hãm tự chủ. Điểm kiểm soát bảo vệ bạn khỏi lãng phí thời gian.
+## ⏳ Checkpoints + tác vụ nền = Bền bỉ lâu dài
+Các bài kiểm thử và build dài hơi không kìm hãm Autonomy. Checkpoints bảo vệ bạn khỏi lãng phí thời gian.
 
 **Ví dụ:**
 Tác nhân chạy bộ kiểm thử Selenium 90 phút sau khi thay đổi UI.
 - Phút thứ 80 → 10% kiểm thử thất bại.
-- Hook kích hoạt quay lại điểm kiểm soát trước khi đổi UI.
+- Hook kích hoạt quay lại Checkpoints trước khi đổi UI.
 - Tác nhân thử lại với bản sửa.
 
 Thay vì bạn phát hiện lỗi vào sáng hôm sau, AI bắt và sửa ngay trong lúc chạy.
@@ -100,15 +100,15 @@ Thay vì bạn phát hiện lỗi vào sáng hôm sau, AI bắt và sửa ngay t
 ---
 
 ## 🧑‍💻 Ý nghĩa với lập trình viên
-Đối với từng lập trình viên, điểm kiểm soát mang lại ba chuyển dịch lớn:
+Đối với từng lập trình viên, Checkpoints mang lại ba chuyển dịch lớn:
 
 1. **Tự do khám phá** — Bạn có thể để tác nhân thử những lần tái cấu trúc táo bạo mà không sợ hỏng hốc vĩnh viễn.
-2. **Tập trung vào kết quả** — Thay vì kiểm soát từng dòng, bạn rà soát các điểm kiểm soát như các commit.
+2. **Tập trung vào kết quả** — Thay vì kiểm soát từng dòng, bạn rà soát các Checkpoints như các commit.
 3. **Tự tin vào khả năng hoàn tác** — Sai lầm không còn đắt giá; chúng chỉ là một trạng thái mà bạn có thể quay lại.
 
 **Ví dụ:**
 Bình thường bạn sẽ không bao giờ để AI chỉnh sửa 20 tệp cùng lúc. Quá rủi ro.
-Với điểm kiểm soát, bạn có thể nói:
+Với Checkpoints, bạn có thể nói:
 > "Tái cấu trúc toàn bộ controller sang async/await."
 Nếu có gì hỏng, bạn chỉ việc tua lại.
 Rủi ro trở nên có thể đảo ngược.
@@ -116,20 +116,20 @@ Rủi ro trở nên có thể đảo ngược.
 ---
 
 ## 🏢 Ý nghĩa với đội ngũ
-Điểm kiểm soát không thay thế Git. Chúng tồn tại trong phiên làm việc cục bộ của tác nhân. Nhưng chúng tạo ra niềm tin.
+Checkpoints không thay thế Git. Chúng tồn tại trong phiên làm việc cục bộ của tác nhân. Nhưng chúng tạo ra niềm tin.
 
 **Ví dụ:**
 Quy trình đội ngũ:
-1. Dev chạy Claude tại máy → nhiều điểm kiểm soát khi AI thử nghiệm.
+1. Dev chạy Claude tại máy → nhiều Checkpoints khi AI thử nghiệm.
 2. Khi ổn định, commit thay đổi → mở PR.
 3. Team review → merge.
 
-Nếu có gì hỏng sau khi merge, bạn vẫn dựa vào lịch sử Git. Nhưng trước khi review, điểm kiểm soát giúp dev tự tin để AI thử nghiệm.
+Nếu có gì hỏng sau khi merge, bạn vẫn dựa vào lịch sử Git. Nhưng trước khi review, Checkpoints giúp dev tự tin để AI thử nghiệm.
 
 ---
 
-## 🌍 Góc nhìn chiến lược: Khả năng tua ngược trước tự động hóa
-Khi nói về tự động hóa của AI, cuộc trò chuyện thường lệch sang năng lực: mô hình lớn hơn, tác nhân thông minh hơn, nhiều công cụ hơn. Nhưng tự chủ không chỉ là AI *có thể* làm gì — mà là chúng ta có thể *tin* nó tới mức nào.
+## 🌍 Góc nhìn chiến lược: Khả năng tua ngược trước Autonomy
+Khi nói về Autonomy của AI, cuộc trò chuyện thường lệch sang năng lực: mô hình lớn hơn, tác nhân thông minh hơn, nhiều công cụ hơn. Nhưng Autonomy không chỉ là AI *có thể* làm gì — mà là chúng ta có thể *tin* nó tới mức nào.
 
 Và niềm tin đến từ kiểm soát.
 
@@ -138,13 +138,13 @@ Trong lịch sử công nghệ, những bước nhảy vọt chỉ xảy ra sau 
 - Hệ điều hành chỉ ổn định khi có **cơ chế cô lập bộ nhớ**.
 - Ô tô chỉ phổ cập khi có **dây an toàn và phanh**.
 
-Với lập trình tự động, tôi tin **điểm kiểm soát là lớp còn thiếu đó**. Chúng không khiến AI "viết code giỏi hơn", nhưng khiến con người dám để AI hành động mà không sợ hãi.
+Với lập trình Autonomy, tôi tin **Checkpoints là lớp còn thiếu đó**. Chúng không khiến AI "viết code giỏi hơn", nhưng khiến con người dám để AI hành động mà không sợ hãi.
 
 **Ví dụ:**
 Cơ sở dữ liệu không được tin dùng cho đến khi bạn có thể `ROLLBACK`.
 Nếu một tác nhân AI đổi tên 500 hàm, bạn cần cùng một đảm bảo: một lệnh để hoàn tác.
 
-Tự chủ mà không thể đảo ngược không phải là kỹ nghệ. Đó là đánh bạc.
+Autonomy mà không thể đảo ngược không phải là kỹ nghệ. Đó là đánh bạc.
 
 ---
 
@@ -152,16 +152,16 @@ Tự chủ mà không thể đảo ngược không phải là kỹ nghệ. Đó 
 Chúng ta đang ở ngưỡng chuyển mình. Hệ thống AI sẽ viết, tái cấu trúc và kiểm thử code độc lập hơn. Nhưng câu hỏi không phải
 là *liệu chúng có làm được hay không*. Đó là *liệu chúng ta có thể tin chúng khi chúng làm hay không.*
 
-Điểm kiểm soát là cơ chế xây dựng niềm tin đó.
+Checkpoints là cơ chế xây dựng niềm tin đó.
 Bởi vì nếu AI sẽ lái repo của bạn, hãy đảm bảo nó biết cách đạp phanh.
 
 ---
 
-### Công cụ lập trình AI — So sánh điểm kiểm soát & hoàn tác
+### Công cụ lập trình AI — So sánh Checkpoints & hoàn tác
 
-| Công cụ | Điểm kiểm soát / Hoàn tác | Phạm vi được chụp nhanh | Cách khôi phục & mức chi tiết | Tác nhân phụ / Điều phối | Tác vụ nền / Chạy dài hạn | Ghi chú cho độc giả |
+| Công cụ | Checkpoints / Hoàn tác | Phạm vi được chụp nhanh | Cách khôi phục & mức chi tiết | Tác nhân phụ / Điều phối | Tác vụ nền / Chạy dài hạn | Ghi chú cho độc giả |
 |---|---|---|---|---|---|---|
-| **Claude Code 2.0** | Có — tự động "checkpoint" trước khi AI chỉnh sửa | Các thay đổi do AI khởi xướng (có thể bao gồm trạng thái hội thoại khi tua) | Tua bằng lệnh/phím tắt; chi tiết cao (theo thay đổi/lệnh) | Tích hợp: hỗ trợ tác nhân phụ, hook và điều phối | Hỗ trợ tác vụ nền; hook có thể kích hoạt kiểm thử/tua lại | Cặp đôi "tác nhân" mạnh nhất: checkpoint + tác nhân phụ + hook giúp tự chủ an toàn | 
+| **Claude Code 2.0** | Có — Checkpoints tự động trước khi AI chỉnh sửa | Các thay đổi do AI khởi xướng (có thể bao gồm trạng thái hội thoại khi tua) | Tua bằng lệnh/phím tắt; chi tiết cao (theo thay đổi/lệnh) | Tích hợp: hỗ trợ tác nhân phụ, hook và điều phối | Hỗ trợ tác vụ nền; hook có thể kích hoạt kiểm thử/tua lại | Cặp đôi "tác nhân" mạnh nhất: Checkpoints + tác nhân phụ + hook giúp Autonomy an toàn |
 | **VS Code Copilot Chat (Agent Mode)** | Có — "Chat Checkpoints" trong VS Code | Tệp làm việc bị AI chỉnh sửa + ngữ cảnh chat | Khôi phục từ cửa sổ chat; theo từng tương tác ("key points") | Một tác nhân điều phối công cụ (terminal, thao tác tệp); có danh sách nhiệm vụ | Có thể chạy build/kiểm thử trong một yêu cầu; chủ yếu tuần tự | Trải nghiệm trong IDE; checkpoint phục hồi cả code *và* chat để giữ phiên nhất quán | 
 | **GitHub Copilot Coding Agent (PR)** | Ngầm định thông qua PR/nhánh (không có UI checkpoint trong IDE) | Thay đổi chỉ tồn tại trong nhánh PR | Loại bỏ PR hoặc revert commit; mức độ thô (theo PR) | "Tác nhân" nền tạo PR; không lộ tác nhân phụ | Chạy tự động ngoài máy bạn; bạn review/merge | An toàn nhờ cách ly (PR). Ít tương tác, nhưng rất an toàn cho đội ngũ | 
 | **Replit AI (Agent & Assistant)** | Có — checkpoint đầy đủ & hoàn tác một cú nhấp | Toàn bộ trạng thái dự án (tệp, phụ thuộc, cấu hình môi trường, chat; tùy chọn DB) | Khôi phục từ lịch sử checkpoint; snapshot theo mốc | Một tác nhân; lập kế hoạch và thực thi tuần tự | Chạy, preview, kiểm thử trong sandbox; rollback có thể khôi phục cả môi trường/DB | Mô hình snapshot đầy đủ nhất (môi trường + code). Tuyệt vời cho quy trình web/app | 
@@ -171,4 +171,4 @@ Bởi vì nếu AI sẽ lái repo của bạn, hãy đảm bảo nó biết các
 | **Continue (VS Code/CLI)** | Một phần — dựa vào Git + "Plan Mode" | Tệp code (khuyến nghị commit nhỏ cho mỗi nhiệm vụ) | Commit/nhánh cho mỗi nhiệm vụ; không có UI checkpoint riêng | Tác nhân tuỳ chỉnh; "workflow" trên cloud mở PR | Workflow nền tạo PR; chế độ tương tác là tuần tự | An toàn nhờ quy trình: Plan Mode (chỉ đọc) → Agent Mode (thực thi) → commit/PR | 
 | **Lovable (App Builder)** | Có — Hoàn tác & lịch sử phiên bản | Phiên bản ứng dụng (code + trạng thái UI trong nền tảng) | Dòng thời gian phiên bản; tua về phiên bản trước | Một tác nhân xây dựng và tinh chỉnh ứng dụng | Triển khai một cú nhấp; không có tác nhân phụ riêng | Thân thiện với người không lập trình; lịch sử phiên bản giống checkpoint cho toàn bộ ứng dụng | 
 
-> Tóm tắt nhanh: **Claude Code 2.0, VS Code, Replit, Cursor và Windsurf** mang lại **khả năng tua ngược một chạm (hoặc một lệnh)**. **Aider và Continue** dựa vào **Git** và quy trình kỷ luật. **Claude Code 2.0** hiện là công cụ phổ biến duy nhất kết hợp **checkpoint tự động cùng tác nhân phụ, hook và tác vụ nền** để hiện thực hoá quy trình tự chủ an toàn.
+> Tóm tắt nhanh: **Claude Code 2.0, VS Code, Replit, Cursor và Windsurf** mang lại **khả năng tua ngược một chạm (hoặc một lệnh)**. **Aider và Continue** dựa vào **Git** và quy trình kỷ luật. **Claude Code 2.0** hiện là công cụ phổ biến duy nhất kết hợp **Checkpoints tự động cùng tác nhân phụ, hook và tác vụ nền** để hiện thực hoá quy trình Autonomy an toàn.

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,68 @@
+---
+---
+@import "minima";
+
+.site-header__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.site-header__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.site-language {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.site-language__current {
+  font-weight: 600;
+}
+
+.lang-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.lang-switcher__current {
+  font-weight: 600;
+}
+
+.lang-switcher__link {
+  text-decoration: none;
+}
+
+.lang-switcher__link:focus,
+.lang-switcher__link:hover {
+  text-decoration: underline;
+}
+
+.lang-switcher__separator {
+  color: inherit;
+}
+
+@media (max-width: 600px) {
+  .site-header__controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .site-language {
+    order: 2;
+  }
+
+  .site-nav {
+    order: 1;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -5,8 +5,6 @@ lang: en
 ref: home
 ---
 
-{% include lang-switcher.html %}
-
 Welcome to **Engineering & AI the Right Way**, a journal dedicated to professional, disciplined engineering practices and the pragmatic use of artificial intelligence.
 
 Here you'll find:

--- a/vi/index.md
+++ b/vi/index.md
@@ -6,8 +6,6 @@ ref: home
 permalink: /vi/
 ---
 
-{% include lang-switcher.html %}
-
 Chào mừng bạn đến với **Kỹ thuật & AI đúng cách** — nhật ký tập trung vào phương pháp kỹ thuật chuyên nghiệp, kỷ luật và cách vận dụng AI một cách thực dụng.
 
 Tại đây bạn sẽ tìm thấy:


### PR DESCRIPTION
## Summary
- add a custom header that surfaces the language label and renders the switcher without exposing raw markup on the home pages
- extend the site stylesheet to style the new language controls for both desktop and mobile widths
- update the Vietnamese translation of the autonomy article to retain domain terms such as Autonomy and Checkpoints in English

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e0a21dfc832db96701a26fb11bcb