### PR TITLE
Fix post date display by setting site timezone

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: >-
   Exploring thoughtful approaches to building resilient engineering systems and using artificial intelligence professionally.
 baseurl: ""
 url: ""
+timezone: Asia/Ho_Chi_Minh
 lang: en
 languages:
   en: English


### PR DESCRIPTION
## Summary
- set the Jekyll site timezone to Asia/Ho_Chi_Minh so post dates render with the intended local day

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68e20167ed88832db188127eb6f30e37