### PR TITLE
Add post on post-boom AI engineering priorities

### DIFF
--- a/_posts/2025-10-06-after-ai-boom.md
+++ b/_posts/2025-10-06-after-ai-boom.md
@@ -1,0 +1,151 @@
+---
+layout: post
+title: "After the AI Boom: Where I’m Putting My Energy"
+description: "Why the next wave of AI engineering will be defined by efficiency, systems depth, and measurable business impact."
+featured: false
+lang: en
+ref: after-ai-boom
+permalink: /after-ai-boom/
+banner: /assets/images/ai-boom-aftermath.svg
+banner_alt: "Illustration of circuits transforming into thriving green branches"
+date: 2025-10-06
+---
+
+# 💥 After the AI Boom: Where I’m Putting My Energy (and Where You Might Too)
+
+I’ve been watching the AI boom with a mix of excitement and unease.
+The excitement is obvious — we’ve never had this much compute power, this many open models, or this much creative potential in one field.
+
+But the unease comes from the scale of it all.
+Hundreds of billions of dollars are flowing into GPUs, model training, and data centers.
+Meanwhile, the revenue from real AI products — the kind that actually sustain themselves — is still small.
+
+It reminds me of every infrastructure bubble before: the dot-com era, the crypto rush, even the solar overbuild of the 2010s.
+The same rhythm: fast money, too many players, too little discipline.
+Eventually, the hype fades, the easy funding disappears, and only the systems that deliver real value survive.
+
+So, if I were you — and I kind of am, just another software engineer trying to think clearly in noisy times — here’s exactly where I’d invest my effort right now.
+
+---
+
+## ⚙️ 1. I’m Focusing on Optimizing LLMs for Cost
+
+Every company that jumped into AI is going to wake up to one reality: running models is expensive.
+Compute, memory, and inference latency are real costs — and most people don’t measure them until it’s too late.
+
+That’s why the engineers who can make AI cheaper to run will be the ones everyone wants to hire.
+
+I’m learning about:
+
+- Model distillation, quantization, and pruning
+- Mixed precision and GPU scheduling
+- Balancing cloud vs. edge vs. on-prem inference
+
+The competitive edge isn’t in building a bigger model anymore — it’s in running smaller models more intelligently.
+That’s where margin, scale, and long-term sustainability come from.
+
+> Stop chasing power. Start mastering efficiency.
+
+---
+
+## 🧠 2. I’m Going Deep Into Architecture and Systems
+
+Most AI builders today live entirely above the stack — they wire up APIs, connect wrappers, and call it “integration.”
+But when the bubble cools, the real differentiator will be who actually understands the system underneath.
+
+I’m talking about:
+
+- Distributed systems and data flow
+- Cache strategy, message queues, and concurrency
+- Failure recovery and observability at scale
+
+When something breaks — and it always will — companies won’t look for someone who can prompt a model.
+They’ll look for someone who can fix the system.
+
+> Depth beats speed. The boom rewarded quick demos; the next era will reward real engineering.
+
+---
+
+## 💡 3. I’m Paying Attention to AI That Ties Into Real Revenue
+
+Not everything needs a new model.
+The real money will be in connecting AI to existing businesses — logistics, healthcare, education, insurance, finance.
+
+That’s where workflows are repetitive, data-rich, and already funded.
+
+I’m asking:
+
+- Can this AI product save time or reduce cost for a business?
+- Can it automate part of a process people already pay for?
+- Can it create measurable output, not just “AI magic”?
+
+Because at the end of the day, “cool” doesn’t pay bills — ROI does.
+
+> Be the engineer who connects AI to cash flow, not hype flow.
+
+---
+
+## 🧩 4. I’m Building for Multi-Model Coordination
+
+I don’t believe in “one model to rule them all.”
+The future will be many models working together — small, large, open, private — orchestrated by logic, memory, and context.
+
+That’s the space I’m most excited about right now: how to coordinate reasoning models, retrieval systems, and tools into a single intelligent workflow.
+
+I’m experimenting with:
+
+- LangGraph, DSPy, and agentic orchestration frameworks
+- Managing multi-model pipelines with cost and latency constraints
+- Designing trustable systems, not just fancy demos
+
+The big opportunity isn’t in training the next GPT — it’s in building the ecosystem where many GPTs can cooperate.
+
+---
+
+## 🧪 5. I’m Getting Serious About Synthetic Data and Evaluation
+
+As AI moves deeper into real work, we’ll need to measure it like we measure any system.
+That means testing, benchmarking, and continuous evaluation — not just vibes.
+
+Synthetic data generation is key here.
+It lets us test rare edge cases, stress-test logic, and debug hallucinations before they reach production.
+
+If you can design pipelines that evaluate models automatically — precision, recall, reasoning, and bias — you’ll be part of the new “QA for AI.”
+And that’s a huge, unsolved space.
+
+---
+
+## ⚖️ What I’m Letting Go Of
+
+- Fancy wrappers with no measurable impact
+- AI demos that don’t connect to revenue
+- Copying prompts instead of designing systems
+- Ignoring cost, power, or latency in architecture decisions
+
+Those are bubble behaviors.
+They might get likes, but they won’t survive the correction.
+
+---
+
+## 🌱 What I’m Building Toward
+
+- Tools that make AI cheaper, auditable, and reliable
+- Frameworks for multi-model coordination
+- Evaluation systems for continuous measurement
+- Integrations where AI actually touches business metrics
+
+That’s not glamorous work — but it’s real, it’s defensible, and it’s what will matter when the hype cycle resets.
+
+---
+
+## 🧭 Final Thought
+
+If you’ve read this far, here’s the short version:
+
+> Learn to optimize LLMs for cost.
+> Deepen your architectural and system thinking.
+> Integrate AI into real revenue.
+> Build for coordination and measurement.
+
+That’s where I’m putting my energy.
+Because when the noise fades — and it will — those who can make AI efficient, measurable, and useful will define the next chapter of this industry.


### PR DESCRIPTION
## Summary
- add a new blog post dated 2025-10-06 outlining five focus areas for engineers navigating the post-boom AI landscape

## Testing
- not run (content-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e31b624cd8832db308723c06480485