### PR TITLE
Add analysis of post-AI boom landscape for engineers

### DIFF
--- a/_posts/2025-10-06-post-ai-reality.md
+++ b/_posts/2025-10-06-post-ai-reality.md
@@ -1,0 +1,83 @@
+---
+layout: post
+title: "The Post-AI Boom Reality Check for Software Engineers"
+description: "A sober look at the risks and opportunities awaiting engineers once the AI funding frenzy cools."
+featured: false
+lang: en
+ref: post-ai-reality
+permalink: /post-ai-reality/
+banner: /assets/images/ai-boom-aftermath.svg
+banner_alt: "Illustration of circuits transforming into thriving green branches"
+date: 2025-10-06
+---
+
+# The Post-AI Boom Reality Check for Software Engineers
+
+The truth is simple: the post-AI-boom environment will be brutal for many software engineers. Below is a balanced, reality-first analysis — the threats and the opportunities, side by side.
+
+---
+
+## ⚠️ I. The Harsh Side — What Will Get Worse
+
+### 1. Over-Supply of “AI Developers”
+The current hype is minting thousands of “prompt engineers,” “AI devs,” and “agent builders” with shallow skills. When the bubble contracts, companies will cut aggressively; only those who can quantify impact or optimize cost will survive. Think of it like the 2001 dot-com bust: many “webmasters” disappeared overnight.
+
+**Who’s at risk:** developers who rely only on wrappers around OpenAI APIs or no-code LLM builders, without deep understanding of data, optimization, or product value.
+
+### 2. Collapse of Startup Demand
+Once capital dries up, many AI startups (especially those training or fine-tuning models) will fail. Engineers at these firms could face layoffs even if they are technically competent. Hiring will swing back toward profitable incumbents (Microsoft, Nvidia, SAP, Oracle) who can afford to sustain large R&D. Outcome: fewer roles, higher hiring bar, more consolidation.
+
+### 3. Automated Replacement of Routine Coding
+Ironically, AI coding assistants (like Claude Code, Cursor, Copilot, Devin, etc.) will reduce demand for mid-level engineers. A senior engineer with AI tooling could replace two or three traditional developers. “Implementation roles” (writing CRUD endpoints, tests, UI plumbing) will shrink fast — just as Photoshop reduced the need for retouching technicians even as design work grew.
+
+### 4. Skill Decay via Abstraction
+Engineers relying too much on Copilot-like tools risk losing architectural intuition. When systems break (data drift, model failures, race conditions), only those who understand the mechanics can debug. The gap between “AI operator” and “AI engineer” will widen — and salaries will polarize accordingly.
+
+### 5. Geopolitical and Power Constraints
+GPU scarcity, electricity limits, and capital bottlenecks will tighten access to compute, especially outside big-tech centers. Expect licensing, API caps, and regional regulation to raise barriers for small developers.
+
+---
+
+## 🌤 II. The Real Opportunities — Narrower and Harder
+Opportunities remain, but they’ll belong to engineers who can survive the correction and adapt to new constraints.
+
+| Area | What Survives | Why |
+| --- | --- | --- |
+| MLOps / Infra Efficiency | Making AI cheaper to run | Cost pressure will be enormous |
+| Enterprise AI Integration | Tying AI to existing revenue streams | ROI visibility wins funding |
+| AI Safety & Compliance | Legal exposure management | Regulation means mandatory spending |
+| Agentic System Orchestration | Multi-model coordination | Less hype, more workflow automation |
+| Synthetic Data & Evaluation | Model testing, auditing, debugging | Companies will need measurement |
+
+---
+
+## ⚔️ III. The Post-Boom Power Shift
+
+| Stakeholder | Before (Boom) | After (Bust) |
+| --- | --- | --- |
+| Big Tech | Capital leader | Dominant monopoly (compute + APIs) |
+| Startups | Rapid funding | Massive attrition |
+| Engineers | Abundance of jobs | Polarization: elite vs. replaceable |
+| Academia | Model research | Funding drought, focus on applied |
+| Freelancers | AI project gold rush | Race to the bottom on pricing |
+
+---
+
+## 🧩 IV. What Software Engineers Should Do Now
+
+1. **Go down the stack.** Learn how models actually work, not just APIs — PyTorch, Triton kernels, inference optimization.
+2. **Go up the stack.** Deliver measurable business value by integrating AI to save time, reduce cost, or open new revenue.
+3. **Avoid the crowded middle.** Generic app builders, agent wrappers, and prompt-only roles will collapse first.
+4. **Stay small, adaptable, and multi-skilled.** In downturns, generalists who can build, deploy, and explain survive.
+5. **Anticipate re-industrialization.** AI will move into manufacturing, logistics, and energy — engineers who blend software with physical systems will dominate.
+
+---
+
+## 🧠 Final Reality Check
+
+The AI bubble will pop not because AI fails, but because capital efficiency fails. When it resets, software engineering bifurcates:
+
+- 🧱 Builders of real systems (infra, agents, pipelines) will remain in high demand.
+- 🎨 Prompt jockeys and hype coders will vanish.
+
+Yes, opportunities remain — but they will belong to engineers who can handle scarcity, justify cost, and think systemically, not those riding the hype curve.


### PR DESCRIPTION
## Summary
- add a new October 6, 2025 article outlining the risks and opportunities for software engineers after the AI funding boom

## Testing
- not run (content changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e31eaf9e38832d9a23d91c5950aeb9